### PR TITLE
Download checkpoints automatically and option to not clean sample names.

### DIFF
--- a/av_bench/evaluate.py
+++ b/av_bench/evaluate.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from pathlib import Path
 from typing import Dict
@@ -9,9 +10,10 @@ from tqdm import tqdm
 from av_bench.metrics import compute_fd, compute_isc, compute_kl
 from av_bench.synchformer.synchformer import Synchformer, make_class_grid
 from av_bench.utils import (unroll_dict, unroll_dict_all_keys, unroll_paired_dict,
-                            unroll_paired_dict_with_key)
+                            unroll_paired_dict_with_key, resolve_ckpt)
 
-_syncformer_ckpt_path = Path(__file__).parent.parent / 'weights' / 'synchformer_state_dict.pth'
+home_dir = os.path.expanduser("~")
+_syncformer_ckpt_path =  Path(home_dir) / '.cache' / 'av-benchmark' / 'weights' / 'synchformer_state_dict.pth'
 log = logging.getLogger()
 device = 'cuda'
 
@@ -23,10 +25,11 @@ def evaluate(gt_audio_cache: Path,
              is_paired: bool = True,
              num_samples: int = 1,
              skip_video_related: bool = False,
-             skip_clap: bool = False) -> Dict[str, float]:
+             skip_clap: bool = False,
+             clean_sample_names: bool = False) -> Dict[str, float]:
 
     sync_model = Synchformer().to(device).eval()
-    sd = torch.load(_syncformer_ckpt_path, weights_only=True)
+    sd = torch.load(resolve_ckpt(_syncformer_ckpt_path), weights_only=True)
     sync_model.load_state_dict(sd)
 
     gt_audio_cache = gt_audio_cache.expanduser()
@@ -57,7 +60,7 @@ def evaluate(gt_audio_cache: Path,
             ib_audio_features = torch.load(pred_audio_cache / 'imagebind_audio.pth',
                                            weights_only=True)
             paired_ib_video_features, paired_ib_audio_features, unpaired_ib_keys = unroll_paired_dict(
-                ib_video_features, ib_audio_features)
+                ib_video_features, ib_audio_features, clean_sample_names=clean_sample_names)
             log.info(f'Unpaired IB features keys: {unpaired_ib_keys}')
         else:
             paired_ib_video_features = paired_ib_audio_features = None
@@ -69,7 +72,7 @@ def evaluate(gt_audio_cache: Path,
             sync_audio_features = torch.load(pred_audio_cache / 'synchformer_audio.pth',
                                              weights_only=True)
             paired_sync_video_features, paired_sync_audio_features, unpaired_sync_keys = unroll_paired_dict(
-                sync_video_features, sync_audio_features)
+                sync_video_features, sync_audio_features, clean_sample_names=clean_sample_names)
             log.info(f'Unpaired Synchformer features keys: {unpaired_sync_keys}')
         else:
             paired_sync_video_features = paired_sync_audio_features = None
@@ -81,7 +84,7 @@ def evaluate(gt_audio_cache: Path,
             laion_clap_audio_features = torch.load(pred_audio_cache / 'clap_laion_audio.pth',
                                                    weights_only=True)
             paired_laion_clap_text_features, paired_laion_clap_audio_features, unpaired_laion_clap_keys = unroll_paired_dict(
-                laion_clap_text_features, laion_clap_audio_features)
+                laion_clap_text_features, laion_clap_audio_features, clean_sample_names=clean_sample_names)
             log.info(f'Unpaired LAION CLAP features keys: {unpaired_laion_clap_keys}')
 
             ms_clap_text_features = torch.load(gt_audio_cache / 'clap_ms_text.pth',
@@ -89,7 +92,7 @@ def evaluate(gt_audio_cache: Path,
             ms_clap_audio_features = torch.load(pred_audio_cache / 'clap_ms_audio.pth',
                                                 weights_only=True)
             paired_ms_clap_text_features, paired_ms_clap_audio_features, unpaired_ms_clap_keys = unroll_paired_dict(
-                ms_clap_text_features, ms_clap_audio_features)
+                ms_clap_text_features, ms_clap_audio_features, clean_sample_names=clean_sample_names)
             log.info(f'Unpaired MS CLAP features keys: {unpaired_ms_clap_keys}')
         else:
             paired_laion_clap_text_features = paired_laion_clap_audio_features = None
@@ -104,11 +107,11 @@ def evaluate(gt_audio_cache: Path,
 
     if is_paired:
         gt_passt_features, pred_passt_features, unpaired_passt_keys = unroll_paired_dict(
-            gt_passt_features, pred_passt_features)
+            gt_passt_features, pred_passt_features, clean_sample_names=clean_sample_names)
         log.info(f'Unpaired PASST features keys: {unpaired_passt_keys}')
 
         gt_passt_logits, pred_passt_logits, unpaired_passt_keys = unroll_paired_dict(
-            gt_passt_logits, pred_passt_logits)
+            gt_passt_logits, pred_passt_logits, clean_sample_names=clean_sample_names)
         log.info(f'Unpaired PASST logits keys: {unpaired_passt_keys}')
 
     else:

--- a/av_bench/extraction_models.py
+++ b/av_bench/extraction_models.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import laion_clap
@@ -11,10 +12,11 @@ from msclap import CLAP
 from av_bench.panns import Cnn14
 from av_bench.synchformer.synchformer import Synchformer
 from av_bench.vggish.vggish import VGGish
+from av_bench.utils import resolve_ckpt
 
-_clap_ckpt_path = Path(
-    __file__).parent.parent / 'weights' / 'music_speech_audioset_epoch_15_esc_89.98.pt'
-_syncformer_ckpt_path = Path(__file__).parent.parent / 'weights' / 'synchformer_state_dict.pth'
+home_dir = os.path.expanduser("~")
+_clap_ckpt_path = Path(home_dir) / '.cache' / 'av-benchmark' / 'weights' / 'music_speech_audioset_epoch_15_esc_89.98.pt'
+_syncformer_ckpt_path =  Path(home_dir) / '.cache' / 'av-benchmark' / 'weights' / 'synchformer_state_dict.pth'
 
 
 class ExtractionModels(nn.Module):
@@ -45,12 +47,12 @@ class ExtractionModels(nn.Module):
         self.imagebind = imagebind_model.imagebind_huge(pretrained=True).eval()
 
         self.laion_clap = laion_clap.CLAP_Module(enable_fusion=False, amodel='HTSAT-base').eval()
-        self.laion_clap.load_ckpt(_clap_ckpt_path, verbose=False)
+        self.laion_clap.load_ckpt(resolve_ckpt(_clap_ckpt_path), verbose=False)
 
         self.ms_clap = CLAP(version='2023', use_cuda=True)
 
         self.synchformer = Synchformer().eval()
-        sd = torch.load(_syncformer_ckpt_path, weights_only=True)
+        sd = torch.load(resolve_ckpt(_syncformer_ckpt_path), weights_only=True)
         self.synchformer.load_state_dict(sd)
 
         # from synchformer

--- a/av_bench/panns/models.py
+++ b/av_bench/panns/models.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 from torchlibrosa.augmentation import SpecAugmentation
 from torchlibrosa.stft import LogmelFilterBank, Spectrogram
 
+from av_bench.utils import resolve_ckpt
 from av_bench.panns.pytorch_utils import (do_mixup, interpolate, pad_framewise_output)
 
 
@@ -245,13 +246,12 @@ class Cnn14(nn.Module):
 
         # self.init_weight()
         if sample_rate == 16000:
-            state_dict = torch.load("%s/.cache/audioldm_eval/ckpt/Cnn14_16k_mAP=0.438.pth" %
-                                    home_dir,
+            state_dict = torch.load(resolve_ckpt("%s/.cache/audioldm_eval/ckpt/Cnn14_16k_mAP=0.438.pth" % home_dir),
                                     map_location="cpu",
                                     weights_only=False)
             self.load_state_dict(state_dict["model"])
         elif sample_rate == 32000:
-            state_dict = torch.load("%s/.cache/audioldm_eval/ckpt/Cnn14_mAP=0.431.pth" % home_dir,
+            state_dict = torch.load(resolve_ckpt("%s/.cache/audioldm_eval/ckpt/Cnn14_mAP=0.431.pth" % home_dir),
                                     map_location="cpu",
                                     weights_only=False)
             self.load_state_dict(state_dict["model"])
@@ -3138,7 +3138,7 @@ class Cnn14_16k(nn.Module):
 
         # self.init_weight()
         home_dir = os.path.expanduser("~")
-        if not os.path.exist("%s/.cache/audioldm_eval/ckpt/Cnn14_mAP=0.431.pth" % home_dir):
+        if not os.path.exists("%s/.cache/audioldm_eval/ckpt/Cnn14_mAP=0.431.pth" % home_dir):
             print("Download pretrained checkpoints of Cnn14.")
             os.makedirs("ckpt", exist_ok=True)
             os.system("wget -P %s/.cache/audioldm_eval/ckpt/ %s" %
@@ -3149,12 +3149,11 @@ class Cnn14_16k(nn.Module):
 
         # self.init_weight()
         if sample_rate == 16000:
-            state_dict = torch.load("%s/.cache/audioldm_eval/ckpt/Cnn14_16k_mAP=0.438.pth" %
-                                    home_dir,
+            state_dict = torch.load(resolve_ckpt("%s/.cache/audioldm_eval/ckpt/Cnn14_16k_mAP=0.438.pth" % home_dir),
                                     weights_only=False)
             self.load_state_dict(state_dict["model"])
         elif sample_rate == 32000:
-            state_dict = torch.load("%s/.cache/audioldm_eval/ckpt/Cnn14_mAP=0.431.pth" % home_dir,
+            state_dict = torch.load(resolve_ckpt("%s/.cache/audioldm_eval/ckpt/Cnn14_mAP=0.431.pth" % home_dir),
                                     weights_only=False)
             self.load_state_dict(state_dict["model"])
 

--- a/av_bench/utils.py
+++ b/av_bench/utils.py
@@ -1,7 +1,72 @@
+from pathlib import Path
+from typing import Optional, Union
 from collections import defaultdict
-from typing import Literal, Optional
+from urllib.request import urlretrieve
 
 import torch
+from tqdm import tqdm
+
+
+CKPT2URL = {
+    'music_speech_audioset_epoch_15_esc_89.98.pt': 'https://huggingface.co/lukewys/laion_clap/resolve/main/music_speech_audioset_epoch_15_esc_89.98.pt',
+    'synchformer_state_dict.pth': 'https://github.com/hkchengrex/MMAudio/releases/download/v0.1/synchformer_state_dict.pth',
+    'Cnn14_16k_mAP=0.438.pth': 'https://zenodo.org/records/3987831/files/Cnn14_16k_mAP=0.438.pth',
+    'Cnn14_mAP=0.431.pth': 'https://zenodo.org/records/3987831/files/Cnn14_mAP=0.431.pth'
+}
+
+
+def resolve_ckpt(ckpt: Union[str, Path]) -> Path:
+    ckpt_path = Path(ckpt)
+
+    if not ckpt_path.exists():
+        if ckpt_path.name not in CKPT2URL:
+            raise ValueError(f"Unknown checkpoint name: {ckpt_path.name}")
+        url = CKPT2URL[ckpt_path.name]
+        print(f"Downloading checkpoint from {url}")
+        ckpt_path.parent.mkdir(parents=True, exist_ok=True)
+        download(url, ckpt_path)
+
+    assert ckpt_path.exists(), f"Checkpoint not found at {ckpt_path}"
+    if ckpt_path.is_file():
+        return ckpt_path
+    else:
+        raise ValueError(f"Invalid checkpoint path: {ckpt_path}")
+
+
+def download(url: str, path: Path) -> None:
+    filename = url.split("/")[-1]
+    with TqdmUpTo(
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+        miniters=1,
+        desc=f"Downloading {filename}",
+    ) as t:
+        urlretrieve(url, path, reporthook=t.update_to, data=None)
+
+
+class TqdmUpTo(tqdm):
+    """
+    Adapted from: https://gist.github.com/leimao/37ff6e990b3226c2c9670a2cd1e4a6f5
+
+    Alternative Class-based version of tqdm.
+    Provides `update_to(n)` which uses `tqdm.update(delta_n)`.
+    Inspired by [twine#242](https://github.com/pypa/twine/pull/242),
+    [here](https://github.com/pypa/twine/commit/42e55e06).
+    """
+
+    def update_to(self, b=1, bsize=1, tsize=None):
+        """
+        b  : int, optional
+            Number of blocks transferred so far [default: 1].
+        bsize  : int, optional
+            Size of each block (in tqdm units) [default: 1].
+        tsize  : int, optional
+            Total size (in tqdm units). If [default: None] remains unchanged.
+        """
+        if tsize is not None:
+            self.total = tsize
+        self.update(b * bsize - self.n)  # will also set self.n = b * bsize
 
 
 def clean_sample_name(sample_name: str) -> str:
@@ -84,8 +149,12 @@ def unroll_paired_dict_with_key(gt_d: dict,
 
 def unroll_paired_dict(gt_dict: dict,
                        pred_dict: dict,
-                       cat: bool = False) -> tuple[torch.Tensor, torch.Tensor, list]:
-    pred_keys_to_sample = {k: clean_sample_name(k) for k in pred_dict.keys()}
+                       cat: bool = False,
+                       clean_sample_names: bool = False) -> tuple[torch.Tensor, torch.Tensor, list]:
+    if clean_sample_names:
+        pred_keys_to_sample = {k: clean_sample_name(k) for k in pred_dict.keys()}
+    else:
+        pred_keys_to_sample = {k: k for k in pred_dict.keys()}
     unpaired_samples = set(gt_dict.keys()) ^ set(pred_keys_to_sample.values())
 
     gt_out_list = []

--- a/extract_text.py
+++ b/extract_text.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from argparse import ArgumentParser
 from pathlib import Path
@@ -9,8 +10,10 @@ from colorlog import ColoredFormatter
 from msclap import CLAP
 from tqdm import tqdm
 
-_clap_ckpt_path = Path(
-    __file__).parent.parent / 'weights' / 'music_speech_audioset_epoch_15_esc_89.98.pt'
+from av_bench.utils import resolve_ckpt
+
+home_dir = os.path.expanduser("~")
+_clap_ckpt_path = Path(home_dir) / '.cache' / 'av-benchmark' / 'weights' / 'music_speech_audioset_epoch_15_esc_89.98.pt'
 log = logging.getLogger()
 device = 'cuda'
 
@@ -41,7 +44,7 @@ def extract(args):
 
     laion_clap_model = laion_clap.CLAP_Module(enable_fusion=False,
                                               amodel='HTSAT-base').cuda().eval()
-    laion_clap_model.load_ckpt(_clap_ckpt_path, verbose=False)
+    laion_clap_model.load_ckpt(resolve_ckpt(_clap_ckpt_path), verbose=False)
 
     ms_clap_model = CLAP(version='2023', use_cuda=True)
 

--- a/extract_video.py
+++ b/extract_video.py
@@ -13,8 +13,10 @@ from tqdm import tqdm
 from av_bench.args import get_eval_parser
 from av_bench.data.video_dataset import VideoDataset, error_avoidance_collate
 from av_bench.synchformer.synchformer import Synchformer
+from av_bench.utils import resolve_ckpt
 
-_syncformer_ckpt_path = Path(__file__).parent.parent / 'weights' / 'synchformer_state_dict.pth'
+home_dir = os.path.expanduser("~")
+_syncformer_ckpt_path = Path(home_dir) / '.cache' / 'av-benchmark' / 'weights' / 'synchformer_state_dict.pth'
 log = logging.getLogger()
 device = 'cuda'
 
@@ -99,7 +101,7 @@ def extract(args):
                         collate_fn=error_avoidance_collate)
 
     sync_model = Synchformer().to(device).eval()
-    sd = torch.load(_syncformer_ckpt_path, weights_only=True)
+    sd = torch.load(resolve_ckpt(_syncformer_ckpt_path), weights_only=True)
     sync_model.load_state_dict(sd)
 
     cmp_encode_video_with_sync = torch.compile(encode_video_with_sync)


### PR DESCRIPTION
## Description

When installing av-bench via pip the weights needed for feature extraction are not downloaded. This commit modifies the code so that the weights are downloaded if they are not found from user cache.

## Type of change

New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I tested installing this to a new env via pip and running evaluations out-of-the-box. 