### PR TITLE
Make compatible with `torch>2.9`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ wget https://github.com/hkchengrex/MMAudio/releases/download/v0.1/synchformer_st
 
 ### 5. Optional: For Video Evaluation
 
-If you plan to evaluate on videos, you will also need `ffmpeg`. Note that torchaudio imposes a maximum version limit (`ffmpeg<7`). You can install it as follows:
+If you plan to evaluate on videos, you will also need `ffmpeg`. 
+For video decoding, `torio` is the default backend because it is the best option for backward compatibility with the existing results.
+If you use `torch>=2.9`, we automatically switch to the `pyav` backend, and the torchaudio `ffmpeg<7` version limit does not apply in that case.
+On a small-scale test, we observed matching outputs between `torio` and `pyav`, but we do not guarantee identical results in all environments or datasets.
+You can install it as follows:
 
 ```bash
 conda install -c conda-forge 'ffmpeg<7'

--- a/av_bench/data/video_dataset.py
+++ b/av_bench/data/video_dataset.py
@@ -5,11 +5,31 @@ import torch
 from torch.utils.data.dataloader import default_collate
 from torch.utils.data.dataset import Dataset
 from torchvision.transforms import v2
-from torio.io import StreamingMediaDecoder
 
+try:
+    from torio.io import StreamingMediaDecoder
+except ImportError:
+    StreamingMediaDecoder = None
+
+try:
+    import av as pyav
+except ImportError:
+    pyav = None
+
+if StreamingMediaDecoder is not None:
+    _VIDEO_BACKEND = 'torio'
+elif pyav is not None:
+    _VIDEO_BACKEND = 'pyav'
+else:
+    raise ImportError(
+        'torio is unavailable and pyav could not be imported. '
+        'Please install pyav (e.g., `pip install av`)'
+    ) from None
 from av_bench.data.ib_data import SpatialCrop
 
 log = logging.getLogger()
+if _VIDEO_BACKEND == 'pyav':
+    log.warning('torio is unavailable; falling back to pyav video decoding.')
 
 # https://github.com/facebookresearch/ImageBind/blob/main/imagebind/data.py
 # https://pytorchvideo.readthedocs.io/en/latest/_modules/pytorchvideo/transforms/functional.html
@@ -58,9 +78,7 @@ class VideoDataset(Dataset):
 
         self.crop = SpatialCrop(_IMAGEBIND_SIZE, 3)
 
-    def sample(self, idx: int) -> dict[str, torch.Tensor]:
-        video_path = self.video_paths[idx]
-
+    def _sample_with_torio(self, video_path: Path) -> tuple[torch.Tensor, torch.Tensor]:
         reader = StreamingMediaDecoder(video_path)
         reader.add_basic_video_stream(
             frames_per_chunk=int(_IMAGEBIND_FPS * self.duration_sec),
@@ -78,6 +96,75 @@ class VideoDataset(Dataset):
 
         ib_chunk = data_chunk[0]
         sync_chunk = data_chunk[1]
+        return ib_chunk, sync_chunk
+
+    def _sample_with_pyav(
+        self,
+        video_path: Path,
+        frame_rate: float,
+        expected_length: int,
+    ) -> torch.Tensor:
+        if pyav is None:
+            raise ImportError('pyav is not installed. Install it with `pip install av`.')
+        container = pyav.open(str(video_path))
+        video_stream = container.streams.video[0]
+        try:
+            graph = pyav.filter.Graph()
+            source = graph.add_buffer(template=video_stream)
+            fps_filter = graph.add('fps', f'fps={frame_rate}:round=near:start_time=0')
+            fmt_filter = graph.add('format', 'pix_fmts=rgb24')
+            sink = graph.add('buffersink')
+            source.link_to(fps_filter)
+            fps_filter.link_to(fmt_filter)
+            fmt_filter.link_to(sink)
+            graph.configure()
+        except Exception as e:
+            raise RuntimeError(f'Unable to build PyAV filter graph for {video_path}: {e}') from e
+
+        frames = []
+        try:
+            for frame_idx, frame in enumerate(container.decode(video_stream)):
+                _ = frame_idx
+                source.push(frame)
+                while (
+                    len(frames) < expected_length
+                ):
+                    try:
+                        out_frame = sink.pull()
+                    except Exception as pull_exc:
+                        if pull_exc.__class__.__name__ in {'BlockingIOError', 'EOFError', 'FFmpegError'}:
+                            break
+                        raise
+                    frames.append(torch.from_numpy(out_frame.to_ndarray(format='rgb24')))
+                if len(frames) >= expected_length:
+                    break
+
+            source.push(None)
+            while len(frames) < expected_length:
+                try:
+                    out_frame = sink.pull()
+                except Exception as pull_exc:
+                    if pull_exc.__class__.__name__ in {'BlockingIOError', 'EOFError', 'FFmpegError'}:
+                        break
+                    raise
+                frames.append(torch.from_numpy(out_frame.to_ndarray(format='rgb24')))
+
+            if len(frames) < expected_length:
+                raise RuntimeError(
+                    f'Video too short {video_path}, expected at least {expected_length} frames at {frame_rate} fps'
+                )
+            return torch.stack(frames[:expected_length])
+        finally:
+            container.close()
+
+    def sample(self, idx: int) -> dict[str, torch.Tensor]:
+        video_path = self.video_paths[idx]
+
+        if _VIDEO_BACKEND == 'torio':
+            ib_chunk, sync_chunk = self._sample_with_torio(video_path)
+        elif _VIDEO_BACKEND == 'pyav':
+            ib_chunk = self._sample_with_pyav(video_path, _IMAGEBIND_FPS, self.ib_expected_length)
+            sync_chunk = self._sample_with_pyav(video_path, _SYNC_FPS, self.sync_expected_length)
         if ib_chunk is None:
             raise RuntimeError(f'IB video returned None {video_path}')
         if ib_chunk.shape[0] < self.ib_expected_length:

--- a/extract_video.py
+++ b/extract_video.py
@@ -14,7 +14,7 @@ from av_bench.args import get_eval_parser
 from av_bench.data.video_dataset import VideoDataset, error_avoidance_collate
 from av_bench.synchformer.synchformer import Synchformer
 
-_syncformer_ckpt_path = Path(__file__).parent.parent / 'weights' / 'synchformer_state_dict.pth'
+_syncformer_ckpt_path = Path(__file__).parent / 'weights' / 'synchformer_state_dict.pth'
 log = logging.getLogger()
 device = 'cuda'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   'imagebind @ git+https://github.com/hkchengrex/ImageBind.git',
   'msclap @ git+https://github.com/hkchengrex/MS-CLAP.git',
   'pandas',
+  'setuptools<81',
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/scripts/test_video_backends.py
+++ b/scripts/test_video_backends.py
@@ -1,0 +1,82 @@
+import argparse
+from pathlib import Path
+
+import torch
+from torchvision.utils import save_image
+
+from av_bench.data.video_dataset import (
+    _IMAGEBIND_FPS,
+    _SYNC_FPS,
+    StreamingMediaDecoder,
+    VideoDataset,
+)
+
+
+def _to_tchw(video: torch.Tensor) -> torch.Tensor:
+    if video.ndim != 4:
+        raise ValueError(f'Expected 4D video tensor, got shape={tuple(video.shape)}')
+    if video.shape[1] == 3:
+        return video
+    if video.shape[0] == 3:
+        return video.permute(1, 0, 2, 3)
+    if video.shape[-1] == 3:
+        return video.permute(0, 3, 1, 2)
+    raise ValueError(f'Could not infer channel dimension for tensor shape={tuple(video.shape)}')
+
+
+def _save_video_frames(video: torch.Tensor, out_dir: Path, prefix: str):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    video_tchw = _to_tchw(video).detach().cpu()
+    for i in range(video_tchw.shape[0]):
+        frame = video_tchw[i].to(torch.float32)
+        if frame.max() > 1.0 or frame.min() < 0.0:
+            frame = frame / 255.0
+        frame = frame.clamp(0.0, 1.0)
+        save_image(frame, out_dir / f'{prefix}_{i:04d}.png')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Compare torio and pyav frame extraction outputs.')
+    parser.add_argument('video_path', type=Path, help='Path to a video file.')
+    parser.add_argument('--backend', choices=['pyav', 'torio', 'both'], default='both')
+    parser.add_argument('--duration-sec', type=float, default=8.0)
+    parser.add_argument('--out-dir', type=Path, default=Path('backend_decode_test'))
+    args = parser.parse_args()
+
+    if not args.video_path.exists():
+        raise FileNotFoundError(f'Video file does not exist: {args.video_path}')
+
+    dataset = VideoDataset([args.video_path], duration_sec=args.duration_sec)
+    run_out_dir = args.out_dir / args.video_path.stem
+    print(f'video={args.video_path}')
+    print(f'duration_sec={args.duration_sec}')
+
+    if args.backend in ('torio', 'both'):
+        if StreamingMediaDecoder is None:
+            print('torio: unavailable (skipped)')
+        else:
+            torio_ib, torio_sync = dataset._sample_with_torio(args.video_path)
+            torio_ib_dir = run_out_dir / 'torio_ib'
+            torio_sync_dir = run_out_dir / 'torio_sync'
+            _save_video_frames(torio_ib, torio_ib_dir, 'frame')
+            _save_video_frames(torio_sync, torio_sync_dir, 'frame')
+            print(f'torio_ib.shape={tuple(torio_ib.shape)}')
+            print(f'torio_sync.shape={tuple(torio_sync.shape)}')
+            print(f'torio_ib.saved_dir={torio_ib_dir}')
+            print(f'torio_sync.saved_dir={torio_sync_dir}')
+
+    if args.backend in ('pyav', 'both'):
+        pyav_ib = dataset._sample_with_pyav(args.video_path, _IMAGEBIND_FPS, dataset.ib_expected_length)
+        pyav_sync = dataset._sample_with_pyav(args.video_path, _SYNC_FPS, dataset.sync_expected_length)
+        pyav_ib_dir = run_out_dir / 'pyav_ib'
+        pyav_sync_dir = run_out_dir / 'pyav_sync'
+        _save_video_frames(pyav_ib, pyav_ib_dir, 'frame')
+        _save_video_frames(pyav_sync, pyav_sync_dir, 'frame')
+        print(f'pyav_ib.shape={tuple(pyav_ib.shape)}')
+        print(f'pyav_sync.shape={tuple(pyav_sync.shape)}')
+        print(f'pyav_ib.saved_dir={pyav_ib_dir}')
+        print(f'pyav_sync.saved_dir={pyav_sync_dir}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
`torch>=2.9` no longer supports `torio.StreamingMediaDecoder`. We have added a `pyav`-backed implementation as a fallback. In a small-scale setting, this implementation produces the exact results as the `torio` backend. 

We have also fixed a few minor bugs. Imposed a `setuptools` version constraint `<81` since ImageBind is getting unhappy about this.

Note: 
In torio-enabled environments, run:
```
python scripts/test_video_backends.py <video_path> to print pixel-level diffs between backends.
```